### PR TITLE
Resolve [ErrorException: Undefined property] - Return changelly errors

### DIFF
--- a/sample.php
+++ b/sample.php
@@ -7,4 +7,10 @@ use Changelly\Changelly;
 // get your key and secret here https://changelly.com/developers#keys
 $changelly = new Changelly('yourApiKey', 'yourApiSecret');
 
-echo json_encode($changelly->getCurrenciesFull());
+echo json_encode($changelly->getCurrenciesFull()) . PHP_EOL;
+
+// Ensure that a basic conversion returns a value
+echo json_encode($changelly->getExchangeAmount('btc', 'eth', 1)) . PHP_EOL;
+
+// Return the error when changelly cannot process the request
+echo json_encode($changelly->getExchangeAmount('btc', 'eth', 22000000)) . PHP_EOL;

--- a/sample.php
+++ b/sample.php
@@ -12,5 +12,10 @@ echo json_encode($changelly->getCurrenciesFull()) . PHP_EOL;
 // Ensure that a basic conversion returns a value
 echo json_encode($changelly->getExchangeAmount('btc', 'eth', 1)) . PHP_EOL;
 
-// Return the error when changelly cannot process the request
-echo json_encode($changelly->getExchangeAmount('btc', 'eth', 22000000)) . PHP_EOL;
+// Throw an error, with a status code of 422, as the request cannot be processed
+try {
+    $changelly->getExchangeAmount('btc', 'eth', 22000000);
+} catch (Exception $e) {
+    echo $e->getCode() . PHP_EOL;
+    echo $e->getMessage() . PHP_EOL;
+}

--- a/src/Changelly.php
+++ b/src/Changelly.php
@@ -141,7 +141,13 @@ class Changelly
         ];
         $response = Unirest\Request::post(self::$endpoint, $headers, $message);
         if ($response->code == 200) {
-            return $response->body->result;
+            $body = $response->body;
+
+            if (isset($body->result)) {
+              return $body->result;
+            }
+
+            return $body->error;
         } else {
             throw new \Exception($response->body, $response->code);
         }

--- a/src/Changelly.php
+++ b/src/Changelly.php
@@ -147,7 +147,7 @@ class Changelly
               return $body->result;
             }
 
-            return $body->error;
+            throw new \Exception(json_encode($body->error), 422);
         } else {
             throw new \Exception($response->body, $response->code);
         }


### PR DESCRIPTION
## Rationale

The Changelly API returns an error if a request is invalid in particular when trying to request **getExchangeAmount**. For example when there isn't enough liquidity or there is a minimum amount required for an exchange to take place. 

## Solution

I've updated `src/Changelly.php` to check that a result exists from the Changelly API service, if not it reverts to using the error which is returned. The sample code has been updated to illustrate the update.

If you are happy with this PR feel free to merge and update your composer package.
